### PR TITLE
Remove emitter closure from LndmobileCallback instances

### DIFF
--- a/LightningKit/Local/LndMobileCallbacks/MessageResponseCallback.swift
+++ b/LightningKit/Local/LndMobileCallbacks/MessageResponseCallback.swift
@@ -3,27 +3,30 @@ import Lndmobile
 import SwiftProtobuf
 
 class MessageResponseCallback<T:Message>: NSObject, LndmobileCallbackProtocol {
-    private let emitter: (SingleEvent<T>) -> Void
+    private var emitter: ((SingleEvent<T>) -> Void)?
     
     init(emitter: @escaping (SingleEvent<T>) -> Void) {
         self.emitter = emitter
     }
     
     func onError(_ error: Error?) {
-        emitter(.error(error ?? LndMobileCallbackError.unknownError))
+        emitter?(.error(error ?? LndMobileCallbackError.unknownError))
     }
     
     func onResponse(_ response: Data?) {
         guard let responseData = response else {
-            emitter(.success(T()))
+            emitter?(.success(T()))
+            emitter = nil
             return
         }
         
         guard let responseMessage = try? T(serializedData: responseData) else {
-            emitter(.error(LndMobileCallbackError.responseCannotBeDecoded))
+            emitter?(.error(LndMobileCallbackError.responseCannotBeDecoded))
+            emitter = nil
             return
         }
         
-        emitter(.success(responseMessage))
+        emitter?(.success(responseMessage))
+        emitter = nil
     }
 }

--- a/LightningKit/Local/LndMobileCallbacks/VoidResponseCallback.swift
+++ b/LightningKit/Local/LndMobileCallbacks/VoidResponseCallback.swift
@@ -2,7 +2,7 @@ import RxSwift
 import Lndmobile
 
 class VoidResponseCallback: NSObject, LndmobileCallbackProtocol {
-    private let emitter: ((SingleEvent<Void>) -> Void)?
+    private var emitter: ((SingleEvent<Void>) -> Void)?
     
     init(emitter: ((SingleEvent<Void>) -> Void)?) {
         self.emitter = emitter
@@ -10,9 +10,11 @@ class VoidResponseCallback: NSObject, LndmobileCallbackProtocol {
     
     func onError(_ error: Error?) {
         emitter?(.error(error ?? LndMobileCallbackError.unknownError))
+        emitter = nil
     }
     
     func onResponse(_ response: Data?) {
         emitter?(.success(Void()))
+        emitter = nil
     }
 }


### PR DESCRIPTION
- Lndmobile keeps(caches or for some other purpose) all the objects passed to it as callbacks. In our callback implementations VoidResponseCallback and MessageResponseCallback we need to release emitter(which holds a context from where it was created) when Single is completed